### PR TITLE
Make anchor links lighter by default

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -15,6 +15,12 @@ p {
 a {
   color: $link-color;
   text-decoration: none;
+  &.anchor {
+    color: #0074d94f;
+  }
+  &.anchor:hover {
+    color: $link-color;
+  }
   &:not(.anchor):hover {
     text-decoration: underline;
   }


### PR DESCRIPTION
They are a bit too visually prominent I think, and it's always nice to have a little color change action on `:hover`.